### PR TITLE
Include link to website in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # reputationCalculator
 
 A reputation calculator project using ReactJS for World of Warcraft
+
+🔗 https://allygator.github.io/wowReputationCalculator/


### PR DESCRIPTION
If people reach the repository and want to look at the website, they can follow the link on the README.

Also, good news! PRs no longer cause a 500 error on GitHub.